### PR TITLE
node state: add maint

### DIFF
--- a/Node.hs
+++ b/Node.hs
@@ -64,6 +64,7 @@ data NodeRes
   | ResDrain
   | ResResv
   | ResDown
+  | ResMaint
   deriving (Eq, Ord, Show)
 
 instance Labeled NodeRes where
@@ -72,6 +73,7 @@ instance Labeled NodeRes where
   label ResDrain = "drain"
   label ResResv = "resv"
   label ResDown = "down"
+  label ResMaint = "maint"
 
 data NodeDesc = NodeDesc
   { descRes :: !NodeRes
@@ -88,6 +90,7 @@ addNode withreason Node{..} = ar ResAlloc nodeAlloc
     s | s == nodeStateRes -> ResResv
       | s == nodeStateDrain && s /= nodeStateRebootRequested -> ResDrain
       | s == nodeStateDown -> ResDown
+      | s == nodeStateMaint -> ResMaint
       | otherwise -> ResFree)
     mempty
       { allocTRES = nodeTRES - allocTRES nodeAlloc

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ General slurm statistics, similar to `sdiag` output.
 Node allocation information.
 Node data is labeled by:
 
-- `state`: `alloc` (anything running on the node), `drain` (only if not set for reboot), `down`, `resv`, `free` (anything else)
+- `state`: `alloc` (anything running on the node), `drain` (only if not set for reboot), `down`, `resv`, `maint`, `free` (anything else)
 - `nodes`: first feature set on the node
 
 Optional query parameters:


### PR DESCRIPTION
We have nodes in `IDLE+MAINTENANCE+RESERVED`. In Grafana, we want to show `MAINTENANCE` as unavailable, and we don't want to filter on `RESERVED` instead, because we have users running jobs in reservations so the usage line would exceed the capacity line.